### PR TITLE
Improved Filtering

### DIFF
--- a/cacher.py
+++ b/cacher.py
@@ -93,6 +93,9 @@ def initialize_spells(backup=True): # loads spell data into memory. backup=False
         for i, x in track(enumerate(data_into_list), description="Scraping spells from the web...", total=len(data_into_list)):
             json_list.append(helpers.scrape_spell(cache_search(helpers.reformat(x))))
 
+        # remove bad data from list
+        helpers.clean_list(json_list)
+
         return json_list
     
     except Exception as e:

--- a/helpers.py
+++ b/helpers.py
@@ -23,6 +23,9 @@ def scrape_spell(spell_name): # scrape spell's info, returns as Spell object
 
     spell_json = scrape_spell_json(spell_name)
 
+    if(spell_json is None):
+        return None
+
     new_spell = Spell.from_json(spell_json)
 
     return new_spell
@@ -116,6 +119,11 @@ def parse_to_json(soup, name): # converts scraped html to json
     "spell_lists": spell_lists
 }
     
+    # prune bad data
+    if None in (json_data.get("name"), json_data.get("school"), json_data.get("level")):
+        return None
+
+    
     return json_data
 
 
@@ -129,4 +137,10 @@ def reformat(string):
     new_string = new_string.replace(":","")
 
 
-    return(new_string)    
+    return(new_string)
+
+
+def clean_list(list):
+
+    list[:] = [item for item in list if item is not None]
+    return

--- a/helpers.py
+++ b/helpers.py
@@ -37,6 +37,16 @@ def spellify_list(list): # converts list of spell dicts to list of Spell objects
 
     return new_list
 
+
+def jsonify_list(list):
+
+    new_list = []
+
+    for item in list:
+        new_list.append(item.to_json())
+
+    return new_list
+
     
 def parse_to_json(soup, name): # converts scraped html to json
 
@@ -57,7 +67,6 @@ def parse_to_json(soup, name): # converts scraped html to json
     for x in spell_html:
 
         if(x.get_text().startswith('Source:')):
-            print('Source...')
             spell_source = x.get_text().split(': ')[1]
         elif(x.get_text().startswith('Casting Time:')):
             pattern = r'Casting Time:\s*(.+?)\nRange:\s*(.+?)\nComponents:\s*(.+?)\nDuration:\s*(.+)'

--- a/search.py
+++ b/search.py
@@ -10,6 +10,8 @@ def filter_spells(list, field, target): # generic filtering method
         filtered_spells = filter_by_class(list, target)
     elif(field.lower()=="school"):
         filtered_spells = filter_by_school(list, target)
+    elif(field.lower()=="component"):
+        filtered_spells = filter_by_component(list, target)
 
     return filtered_spells
 
@@ -28,3 +30,13 @@ def filter_by_school(list, filter_school): #  returns list of spells of a specif
     return filtered_spells
 
 
+def filter_by_component(list, filter_component, has_component=True):
+
+    filtered_spells = None
+
+    if has_component:
+        filtered_spells = [spell for spell in list if spell.has_component(filter_component.upper())]
+    else:
+        filtered_spells = [spell for spell in list if not spell.has_component(filter_component.upper())]
+
+    return filtered_spells

--- a/search.py
+++ b/search.py
@@ -16,14 +16,14 @@ def filter_spells(list, field, target): # generic filtering method
 
 def filter_by_class(list, filter_class): # returns list of spells belonging to a specified class
 
-    filtered_spells = [spell for spell in list if filter_class in [s.lower() for s in spell.spell_lists]] # TODO: handling for Tasha's optional spell lists
+    filtered_spells = [spell for spell in list if filter_class.lower() in [s.lower() for s in spell.spell_lists]] # TODO: handling for Tasha's optional spell lists
     
     return filtered_spells
 
 
 def filter_by_school(list, filter_school): #  returns list of spells of a specific school
 
-    filtered_spells = [spell for spell in list if filter_school.lower() == spell.school.lower()]
+    filtered_spells = [spell for spell in list if spell.school.lower()==filter_school.lower()]
     
     return filtered_spells
 

--- a/search.py
+++ b/search.py
@@ -12,6 +12,8 @@ def filter_spells(list, field, target): # generic filtering method
         filtered_spells = filter_by_school(list, target)
     elif(field.lower()=="component"):
         filtered_spells = filter_by_component(list, target)
+    elif(field.lower()=="conc"):
+        filtered_spells = filter_by_concentration(list)
 
     return filtered_spells
 
@@ -25,7 +27,7 @@ def filter_by_class(list, filter_class): # returns list of spells belonging to a
 
 def filter_by_school(list, filter_school): #  returns list of spells of a specific school
 
-    filtered_spells = [spell for spell in list if spell.school.lower()==filter_school.lower()]
+    filtered_spells = [spell for spell in list if spell.school.lower() == filter_school.lower()]
     
     return filtered_spells
 
@@ -39,4 +41,16 @@ def filter_by_component(list, filter_component, has_component=True):
     else:
         filtered_spells = [spell for spell in list if not spell.has_component(filter_component.upper())]
 
+    return filtered_spells
+
+
+def filter_by_concentration(list, invert=False):
+
+    filtered_spells = None
+
+    if invert:
+        filtered_spells = [spell for spell in list if not spell.is_concentration()]
+    else:
+        filtered_spells = [spell for spell in list if spell.is_concentration()]
+    
     return filtered_spells

--- a/search.py
+++ b/search.py
@@ -1,19 +1,48 @@
 from spell import Spell
 import helpers
+import argparse
+import shlex
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="Filter spells based on flags.")
+    parser.add_argument("-c",  "--class", nargs="+", help="Filter by spell class")
+    parser.add_argument("-s", "--school", nargs="+", help="Filter by spell school")
+    parser.add_argument("-l", "--level",  nargs="+", help="Filter by spell level")
+    parser.add_argument("-cmp", "--component", nargs="+", help="Filter by spell components")
+    parser.add_argument("-con", "--concentration", nargs="?", const=True, help="filter spells with concentration")   
+
+    return parser
 
 
-def filter_spells(list, field, target): # generic filtering method
+def parse_query(user_input):
 
-    filtered_spells = None
+    parser = build_parser()
+    args, unknown_args = parser.parse_known_args(shlex.split(user_input))
+    return vars(args)
 
-    if(field.lower()=="class"):
-        filtered_spells = filter_by_class(list, target)
-    elif(field.lower()=="school"):
-        filtered_spells = filter_by_school(list, target)
-    elif(field.lower()=="component"):
-        filtered_spells = filter_by_component(list, target)
-    elif(field.lower()=="conc"):
-        filtered_spells = filter_by_concentration(list)
+
+def filter_spells(list, search_filters): # generic filtering method
+
+    filtered_spells = list
+
+    class_filters = search_filters.get('class')
+    school_filter = search_filters.get('school')
+    component_filters = search_filters.get('component')
+    concentration_filter = search_filters.get('concentration')
+
+    if class_filters:
+        for arg in class_filters:
+            filtered_spells = filter_by_class(filtered_spells, arg)
+
+    if component_filters:
+        for arg in component_filters:
+            filtered_spells = filter_by_component(filtered_spells, arg) # TODO: ability to search for spells without a certain component
+
+    if school_filter:
+        filtered_spells = filter_by_school(filtered_spells, school_filter[0])
+
+    if concentration_filter:
+        filtered_spells = filter_by_concentration(filtered_spells, concentration_filter)
 
     return filtered_spells
 
@@ -44,13 +73,13 @@ def filter_by_component(list, filter_component, has_component=True):
     return filtered_spells
 
 
-def filter_by_concentration(list, invert=False):
+def filter_by_concentration(list, is_concentration=True):
 
     filtered_spells = None
 
-    if invert:
-        filtered_spells = [spell for spell in list if not spell.is_concentration()]
-    else:
+    if is_concentration:
         filtered_spells = [spell for spell in list if spell.is_concentration()]
+    else:
+        filtered_spells = [spell for spell in list if not spell.is_concentration()]
     
     return filtered_spells

--- a/spell.py
+++ b/spell.py
@@ -57,24 +57,16 @@ class Spell:
             return True
         else:
             return False
+        
+    def level_to_int(self):
+        
+        if self.level == 'Cantrip':
+            return 0
+        elif self.level[0].isnumeric():
+            return int(self.level[0])
+
 
     @classmethod
     def from_json(cls, json_data):
         return cls(**json_data)
 
-# json_data = {
-#     "name": "Fireball",
-#     "school": "Evocation",
-#     "level": "3rd",
-#     "duration": "Instantaneous",
-#     "cast_time": "1 action",
-#     "cast_range": "150 feet",
-#     "components": ['V', 'S'],
-#     "source": 'PHB',
-#     "description": "A bright streak flashes from your pointing finger to a point you choose within range and then blossoms with a low roar into an explosion of flame.",
-#     "upcast": None,
-#     "spell_lists": ['Wizard', 'Sorcerer']
-# }
-
-#spell = Spell.from_json(json_data)
-#print(spell.output())  # Output: Fireball

--- a/spell.py
+++ b/spell.py
@@ -50,7 +50,13 @@ class Spell:
             return False
         else:
             return True
-
+        
+    def is_concentration(self):
+        
+        if 'Concentration' in self.duration:
+            return True
+        else:
+            return False
 
     @classmethod
     def from_json(cls, json_data):


### PR DESCRIPTION
Refactored `search.py` and expanded filtering capabilities using `argparse`:

- Added filtering by spell components (any combination of V, S, M)
- Added filtering by concentration (or lack thereof with `-con false`)
- Added filtering by spell level
  - can filter by multiple levels (ex. `-l 2 3` filters for level 2 and 3 spells)
  - can filter by level ranges (ex. `-l 0..5` filters for spells from cantrips to level 5)
- Can now filter for multiple classes (ex. `-c druid wizard`)

Modified scraping methods in `helpers.py` to prune bad/unexpected HTML