### PR TITLE
Data cleaning & HTML parsing improvements

### DIFF
--- a/src/cacher.py
+++ b/src/cacher.py
@@ -91,10 +91,11 @@ def initialize_spells(backup=True): # loads spell data into memory. backup=False
         json_list = []
 
         for i, new_spell_info in track(enumerate(data_into_list), description="Scraping spells from the web...", total=len(data_into_list)):
-            json_list.append(helpers.scrape_spell(cache_search(helpers.reformat(new_spell_info))))
+            scraped_spell = helpers.scrape_spell(cache_search(helpers.reformat(new_spell_info)))
+            json_list.append(scraped_spell)
 
         # remove bad data from list
-        helpers.clean_list(json_list)
+        json_list = helpers.clean_list(json_list)
 
         return json_list
     

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -150,15 +150,25 @@ def reformat(string):
     return(new_string)
 
 
-def clean_list(list):
+def clean_list(spell_list): # removes invalid & duplicate items from a provided list
 
-    list[:] = [item for item in list if item is not None]
-    return
+    # remove invalid items
+    temp_list = [item for item in spell_list if isinstance(item, Spell)]
+
+    seen_spells = []
+    final_list = []
+    # remove duplicates
+    for spell in temp_list:
+        if(spell.name not in seen_spells):
+            seen_spells.append(spell.name)
+            final_list.append(spell)
+
+    return final_list
 
 
-def find_closest_spell(list, target): # finds closest matching spell name in a list of strings
+def find_closest_spell(spell_list, target): # finds closest matching spell name in a list of strings
 
     try:
-        return get_close_matches(target, list, 1)[0]
+        return get_close_matches(target, spell_list, 1)[0]
     except:
         return None


### PR DESCRIPTION
Fixed an issue where the parser would not properly copy the description of a few spells with unusually long descriptions (such as Hex, Wish, Summon Undead). These spells are formatted slightly differently, with their descriptions being broken up into multiple \<p> tags. `parse_to_json()` now concatenates all of these rather than just taking the value of the last one.

`clean_list()` has been modified to remove any item that is not a `Spell` rather than just removing `None` from the list. Additionally, the method now removes duplicate spell entries, a few of which exist on the site due to UA spells being reprinted into source books with no changes (ex. Draconic Transformation, Antagonize, Spray of Cards).