### PR TITLE
Discord /search command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -43,7 +43,9 @@ async def spell(interaction: discord.Interaction, spell_name: str):
 @app_commands.rename(spell_class="class")
 async def search(interaction: discord.Interaction, spell_class: str = None, school: str = None, results: int = 10):
     await interaction.response.defer()
-    await send_paginated_embed(interaction, bot.spells, per_page=results)
+    search_query = format_query(target_class=spell_class, school=school)
+    filters = searcher.parse_query(search_query)
+    await send_paginated_embed(interaction, searcher.filter_spells(bot.spells, filters), per_page=results)
 
 
 async def send_spell_embed(message, spell):
@@ -78,6 +80,18 @@ async def send_spell_embed(message, spell):
 
     return spell_embed
 
+
+def format_query(target_class=None, school=None, level=None, components=None, con=None):
+    query_string = ""
+
+    if(target_class):
+        query_string+="-c "+target_class
+    if(school):
+        query_string+=" -s "+school
+    if(level):
+        query_string+=" -l "+level
+
+    return query_string
 
 # helpers for creating & formatting spell entries on the embed
 def combine_spell_and_school(spell):

--- a/bot.py
+++ b/bot.py
@@ -3,9 +3,9 @@ from discord import app_commands
 from discord.ext import commands
 import src.cacher as cacher
 import src.helpers as helpers
-import src.search as search
-import src.spell as spell
+import src.search as searcher
 from pathlib import Path
+import asyncio
 
 intents = discord.Intents.default()
 intents.message_content = True
@@ -21,22 +21,29 @@ async def on_ready():
     if(bot.spells == None):
         print("Failed to initialize spells")
     else:
-        print('Successfully initialized spells')
+        print(f'Successfully initialized {len(bot.spells)} spells')
         
     try:
         synced = await bot.tree.sync()
-        print(f"Successfully synced commands")
+        print(f"Successfully synced {len(synced)} commands (may take a few minutes to update)")
     except:
         print("Failed to sync commands")
 
 
-@bot.tree.command(name="info", description='Displays spell information')
-@app_commands.describe(spell_name = "Name of spell to look up")
+@bot.tree.command(name="spell", description='Displays spell information')
+@app_commands.describe(spell_name = "Name of spell to display")
 @app_commands.rename(spell_name="name")
-async def info(interaction: discord.Interaction, spell_name: str):
-    target_spell = search.fetch_spell(bot.spells, spell_name)
+async def spell(interaction: discord.Interaction, spell_name: str):
+    target_spell = searcher.fetch_spell(bot.spells, spell_name)
     spell_embed = await send_spell_embed(interaction, target_spell)
     await interaction.response.send_message(embed=spell_embed)
+
+@bot.tree.command(name="search", description='Lists spells that match your search criteria')
+@app_commands.describe(spell_class = "Filter for spells available to specific classes (separated by spaces)", school = "Filter for spells belonging to a specific school", results = "Number of spells displayed per page")
+@app_commands.rename(spell_class="class")
+async def search(interaction: discord.Interaction, spell_class: str = None, school: str = None, results: int = 10):
+    await interaction.response.defer()
+    await send_paginated_embed(interaction, bot.spells, per_page=results)
 
 
 async def send_spell_embed(message, spell):
@@ -71,5 +78,69 @@ async def send_spell_embed(message, spell):
 
     return spell_embed
 
+
+# helpers for creating & formatting spell entries on the embed
+def combine_spell_and_school(spell):
+    if spell.level.lower() == "cantrip":
+        return spell.school + " " + spell.level.lower()
+    else:
+        return spell.level + " " + spell.school.lower()
+
+
+def paginated_description(spell, desc_length=140):
+    if len(spell.description)<desc_length:
+        return spell.description[:desc_length].replace("\n"," ")
+    else:
+        return spell.description[:desc_length].replace("\n"," ") + "..."
+
+
+def add_paginated_spell(embed, spell):
+    embed.add_field(name=spell.name+" *("+combine_spell_and_school(spell)+")*", value="-# "+paginated_description(spell), inline=False)
+
+
+async def send_paginated_embed(message, spells, page=0, per_page=10):
+    page_embed = discord.Embed(title="📜 Spell List", color=discord.Color.green())
+
+    # calculate page indices
+    last_page_index = (len(spells) - 1) // per_page
+    start_index = page * per_page
+    end_index = start_index + per_page
+
+    # add spells to page embed
+    for spell in spells[start_index:end_index]:
+        add_paginated_spell(page_embed, spell)
+
+    page_embed.set_footer(text=f"Page {page + 1} of {last_page_index + 1}")
+    sent_message = await message.followup.send(embed=page_embed)
+
+    if last_page_index > 0:  # don't add reactions if there's only one page
+        await sent_message.add_reaction("⬅️")
+        await sent_message.add_reaction("➡️")
+
+    # handler for changing pages
+    def check(reaction, user):
+        return user == message.user and reaction.message.id == sent_message.id and reaction.emoji in ["⬅️", "➡️"]
+
+    while last_page_index > 0: # enter loop if more than one page exists
+        try:
+            reaction, user = await bot.wait_for("reaction_add", timeout=30.0, check=check)
+
+            if str(reaction.emoji) == "➡️" and page < last_page_index:
+                page += 1
+            elif str(reaction.emoji) == "⬅️" and page > 0:
+                page -= 1
+
+            # update embed with new page's spells
+            page_embed.clear_fields()
+            for spell in spells[page * per_page: (page + 1) * per_page]:
+                add_paginated_spell(page_embed, spell)
+
+            page_embed.set_footer(text=f"Page {page + 1} of {last_page_index + 1}")
+
+            await sent_message.edit(embed=page_embed)
+            await sent_message.remove_reaction(reaction.emoji, user)
+
+        except asyncio.TimeoutError: # exit the loop after timeout (30 sec)
+            break
 
 bot.run('TOKEN')

--- a/bot.py
+++ b/bot.py
@@ -30,10 +30,13 @@ async def on_ready():
         print("Failed to sync commands")
 
 
-@bot.tree.command(name="info")
+@bot.tree.command(name="info", description='Displays spell information')
 @app_commands.describe(spell_name = "Name of spell to look up")
+@app_commands.rename(spell_name="name")
 async def info(interaction: discord.Interaction, spell_name: str):
-    await send_spell_embed(interaction, search.fetch_spell(bot.spells, spell_name))
+    target_spell = search.fetch_spell(bot.spells, spell_name)
+    spell_embed = await send_spell_embed(interaction, target_spell)
+    await interaction.response.send_message(embed=spell_embed)
 
 
 async def send_spell_embed(message, spell):
@@ -45,22 +48,9 @@ async def send_spell_embed(message, spell):
     else: # levelled spell formatting
         spell_school_level = f"{spell.level.lower()} {spell.school.lower()}"
 
-    # format spell components
-    component_text = ''
-    if len(spell.components) != 0:
-        for index, spell_component in enumerate(spell.components):
-            component_text = component_text + spell_component
-
-            if index != len(spell.components) - 1:
-                component_text = component_text + ", "
-
-    # format spell lists
-    corresponding_spell_lists = ''
-    for index, class_name in enumerate(spell.spell_lists):
-        corresponding_spell_lists = corresponding_spell_lists + class_name
-        if index != len(spell.spell_lists) - 1:
-            corresponding_spell_lists = corresponding_spell_lists+", "
-
+    component_text = ", ".join(spell.components)
+    corresponding_spell_lists = ", ".join(spell.spell_lists)
+ 
     spell_embed = discord.Embed(
         title=spell.name,
         description=f"*{spell_school_level}*\n",
@@ -79,7 +69,7 @@ async def send_spell_embed(message, spell):
     spell_embed.add_field(name="🧙‍♂️ Spell Lists",value=corresponding_spell_lists, inline=False)
     spell_embed.set_footer(text=f"📜 Source: {spell.source}")
 
-    await message.channel.send(embed=spell_embed)
+    return spell_embed
 
 
 bot.run('TOKEN')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+beautifulsoup4==4.13.4
+discord.py==2.5.2
+Requests==2.32.3
+rich==14.0.0


### PR DESCRIPTION
# bot.py
- Made `/search` slash command, functions like CLI counterpart. Currently supports filtering by class and school
- `format_query()`, new method that converts `/search` arguments into a string compatible with the filtering logic of `search.py`
- `combine_level_and_school()`, a helper that reformats a spell's level and school attributes to match wikidot's format
- `paginated_description()`, a helper that formats description text for paginated spell embeds
- `add_paginated_spell()`, helper that adds a spell field to a spell list embed
- `send_paginated_embed()`, new method that posts a spell list embed with pagination support
