### PR TITLE
Expanded filtering functionality (Ritual, UA and HB)

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14,14 +14,14 @@ def format_query(target_class=None, school=None, level=None, components=None, co
 
     if(target_class):
         query_string+="-c "+target_class
-    if(school):
+    if school:
         query_string+=" -s "+school
-    if(level):
+    if level:
         query_string+=" -l "+level.replace("-","..")
-    if(components):
+    if components:
         query_string+=" -cmp "+components
-    if(con):
-        query_string+=" -con "+con
+    if con is not None: # con is a bool
+        query_string+=" -con "+str(con)
 
     return query_string
 
@@ -37,7 +37,7 @@ def combine_level_and_school(spell):
     if spell.level.lower() == "cantrip":
         return spell.school + " " + spell.level.lower()
     else:
-        return spell.level + " " + spell.school.lower()
+        return spell.level.lower() + " " + spell.school.lower()
     
 # truncates a spell's description to a provided length
 def paginated_description(spell, desc_length=140):
@@ -162,13 +162,13 @@ async def spell(interaction: discord.Interaction, spell_name: str):
 
 @bot.tree.command(name="search", description='Lists spells that match your search criteria')
 @app_commands.describe(spell_class = "Filter for spells available to specific classes (separated by spaces)", school = "Filter for spells belonging to a specific school", level = "Filter based on spell levels (\"0-3\" includes spells from cantrips to level 3)", 
-    comps = "Filter by spell components (any combo of V, S, M)", results = "Number of spells displayed per page")
+    comps = "Filter by spell components (any combo of V, S, M)", con="True = only concentration spells, false = only non-concentration", results = "Number of spells displayed per page")
 @app_commands.rename(spell_class="class")
 @app_commands.autocomplete(spell_class=spell_class_autocomplete)
 async def search(interaction: discord.Interaction, spell_class: str= None, school: Literal["Abjuration", "Conjuration", "Divination", "Enchantment", "Evocation", "Illusion", "Necromancy", "Transmutation"] = None,
-    level: str = None, comps: str = None, results: int = 10):
+    level: str = None, comps: str = None, con: bool = None, results: int = 10):
     await interaction.response.defer()
-    search_query = format_query(target_class=spell_class, school=school, level=level, components=comps)
+    search_query = format_query(target_class=spell_class, school=school, level=level, components=comps, con=con)
     filters = searcher.parse_query(search_query)
     await send_paginated_embed(interaction, searcher.filter_spells(bot.spells, filters), per_page=results)
 

--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,7 @@ import asyncio
 from typing import Literal
 
 # reformats /search arguments into a format compatible with search.py's parser
-def format_query(target_class=None, school=None, level=None, components=None, con=None):
+def format_query(target_class=None, school=None, level=None, components=None, con=None, ritual=None):
     query_string = ""
 
     if(target_class):
@@ -22,6 +22,8 @@ def format_query(target_class=None, school=None, level=None, components=None, co
         query_string+=" -cmp "+components
     if con is not None: # con is a bool
         query_string+=" -con "+str(con)
+    if ritual is not None:
+        query_string+=" -r "+str(ritual)
 
     return query_string
 
@@ -59,6 +61,9 @@ async def send_spell_embed(message, spell):
         spell_school_level = f"{spell.school} {spell.level.lower()}"
     else: # levelled spell formatting
         spell_school_level = f"{spell.level.lower()} {spell.school.lower()}"
+
+    if spell.is_ritual():
+        spell_school_level += " (ritual)"
 
     component_text = ", ".join(spell.components)
     corresponding_spell_lists = ", ".join(spell.spell_lists)
@@ -162,13 +167,13 @@ async def spell(interaction: discord.Interaction, spell_name: str):
 
 @bot.tree.command(name="search", description='Lists spells that match your search criteria')
 @app_commands.describe(spell_class = "Filter for spells available to specific classes (separated by spaces)", school = "Filter for spells belonging to a specific school", level = "Filter based on spell levels (\"0-3\" includes spells from cantrips to level 3)", 
-    comps = "Filter by spell components (any combo of V, S, M)", con="True = only concentration spells, false = only non-concentration", results = "Number of spells displayed per page")
+    comps = "Filter by spell components (any combo of V, S, M)", con="True = only concentration spells, false = only non-concentration", ritual="True = spells with the ritual tag, false = spells without it", results = "Number of spells displayed per page")
 @app_commands.rename(spell_class="class")
 @app_commands.autocomplete(spell_class=spell_class_autocomplete)
 async def search(interaction: discord.Interaction, spell_class: str= None, school: Literal["Abjuration", "Conjuration", "Divination", "Enchantment", "Evocation", "Illusion", "Necromancy", "Transmutation"] = None,
-    level: str = None, comps: str = None, con: bool = None, results: int = 10):
+    level: str = None, comps: str = None, con: bool = None, ritual: bool = None, results: int = 10):
     await interaction.response.defer()
-    search_query = format_query(target_class=spell_class, school=school, level=level, components=comps, con=con)
+    search_query = format_query(target_class=spell_class, school=school, level=level, components=comps, con=con, ritual=ritual)
     filters = searcher.parse_query(search_query)
     await send_paginated_embed(interaction, searcher.filter_spells(bot.spells, filters), per_page=results)
 

--- a/src/control.py
+++ b/src/control.py
@@ -9,7 +9,7 @@ from rich.panel import Panel
 from rich import box
 from rich.table import Table
 from rich.text import Text
-from rich.prompt import Prompt, IntPrompt
+from rich.prompt import Prompt
 
 def display_spell(spell):
         console = Console()
@@ -25,7 +25,11 @@ def display_spell(spell):
         spell_info.append(f"{spell.duration}\n", style="green")
 
         spell_info.append(f"Cast Time: ", style="bold magenta")
-        spell_info.append(f"{spell.cast_time}\n", style="magenta")
+        spell_info.append(f"{spell.cast_time}", style="magenta")
+        
+        if spell.is_ritual():
+            spell_info.append(f" (ritual)", style="italic magenta")
+        spell_info.append("\n")
 
         spell_info.append(f"Range: ", style="bold blue")
         spell_info.append(f"{spell.cast_range}\n", style="blue")
@@ -92,7 +96,7 @@ def display_menu():
 
     console.print(menu_table)
 
-    selected_option = Prompt.ask("[bold yellow]Please select an option[/]", choices=["1", "2", "3", "4", "5", "6"])
+    selected_option = Prompt.ask("[bold yellow]Please select an option[/]", choices=["1", "2", "3", "4", "5"])
 
     return selected_option
 
@@ -106,7 +110,6 @@ def display_help_menu():
     table.add_column("[orchid]Description[/]", style="sea_green2")
     table.add_column("[orchid]Example[/]", style="bold")
 
-    # Add rows
     table.add_row("-c, --class", 
                 "Filters for spells that belong to specified classes.", 
                 "[bold yellow]-c Bard Wizard[/] filters for spells available to both Bards and Wizards.")
@@ -127,6 +130,10 @@ def display_help_menu():
     table.add_row("-con, --concentration", 
                 "Filter spells with concentration.", 
                 "[bold yellow]-con[/] filters for concentration spells. [bold yellow]-con false[/] excludes them.")
+    
+    table.add_row("-r, --ritual", 
+                "Filter for spells with the ritual tag.", 
+                "[bold yellow]-r[/] filters for ritual spells. [bold yellow]-r false[/] excludes them.")
 
     console.print(table)
 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -66,6 +66,7 @@ def parse_to_json(soup, name): # converts scraped html to json
     spell_description = ""
     spell_upcast = None
     spell_lists = []
+    is_ritual = False
 
     spell_html = soup.find_all('p')
 
@@ -81,6 +82,8 @@ def parse_to_json(soup, name): # converts scraped html to json
         (level for level in SPELL_LEVELS if level.lower() in emphasis_text.lower()),
     None)
 
+    if "ritual" in emphasis_text:
+        is_ritual = True
 
     for x in spell_html:
 
@@ -126,7 +129,8 @@ def parse_to_json(soup, name): # converts scraped html to json
     "source": spell_source,
     "description": spell_description,
     "upcast": spell_upcast,
-    "spell_lists": spell_lists
+    "spell_lists": spell_lists,
+    "ritual": is_ritual
 }
     
     # prune bad data

--- a/src/search.py
+++ b/src/search.py
@@ -11,6 +11,7 @@ def build_parser():
     parser.add_argument("-l", "--level",  nargs="+", help="Filter by spell level")
     parser.add_argument("-cmp", "--component", nargs="+", help="Filter by spell components. Valid inputs are the letters v s m")
     parser.add_argument("-con", "--concentration", nargs="?", const=True, type=lambda input_str: input_str.lower() == "true", help="filter spells with concentration. -con false will exclude concentration spells.")   
+    parser.add_argument("-r", "--ritual", nargs="?", const=True, type=lambda input_str: input_str.lower() == "true", help="filter spells with the ritual tag. -r false will exclude concentration spells.")
 
     return parser
 
@@ -31,6 +32,7 @@ def filter_spells(list, search_filters): # generic filtering method
     component_filters = search_filters.get('component')
     concentration_filter = search_filters.get('concentration')
     level_filter = search_filters.get('level')
+    ritual_filter = search_filters.get('ritual')
 
     if class_filters:
         for arg in class_filters:
@@ -46,8 +48,10 @@ def filter_spells(list, search_filters): # generic filtering method
     if concentration_filter is not None: # concentration_filter is a bool
         filtered_spells = filter_by_concentration(filtered_spells, concentration_filter)
 
+    if ritual_filter is not None: # ritual_filter is a bool
+        filtered_spells = filter_by_ritual(filtered_spells, ritual_filter)
+
     if level_filter:
-        
         filtered_spells = filter_by_level(filtered_spells, level_filter)
 
     return filtered_spells
@@ -100,6 +104,18 @@ def filter_by_level(list, levels):
     return filtered_spells
 
 
+def filter_by_ritual(list, is_ritual = True):
+
+    filtered_spells = None
+
+    if is_ritual == True:
+         filtered_spells = [spell for spell in list if spell.is_ritual()]
+    else:
+         filtered_spells = [spell for spell in list if not spell.is_ritual()]
+
+    return filtered_spells
+
+
 def filter_ua(list):
 
     filtered_spells = [spell for spell in list if "(UA)" not in spell.name]
@@ -117,7 +133,6 @@ def filter_hb(list):
 def parse_level_range(level_filter):
     
     levels = []
-
 
     for arg in level_filter:
         if arg.isdigit():

--- a/src/search.py
+++ b/src/search.py
@@ -100,6 +100,20 @@ def filter_by_level(list, levels):
     return filtered_spells
 
 
+def filter_ua(list):
+
+    filtered_spells = [spell for spell in list if "(UA)" not in spell.name]
+
+    return filtered_spells
+
+
+def filter_hb(list):
+
+    filtered_spells = [spell for spell in list if "(HB)" not in spell.name]
+
+    return filtered_spells
+
+
 def parse_level_range(level_filter):
     
     levels = []

--- a/src/search.py
+++ b/src/search.py
@@ -10,7 +10,7 @@ def build_parser():
     parser.add_argument("-s", "--school", nargs="+", help="Filter by spell school")
     parser.add_argument("-l", "--level",  nargs="+", help="Filter by spell level")
     parser.add_argument("-cmp", "--component", nargs="+", help="Filter by spell components. Valid inputs are the letters v s m")
-    parser.add_argument("-con", "--concentration", nargs="?", const=True, help="filter spells with concentration. -con false will exclude concentration spells.")   
+    parser.add_argument("-con", "--concentration", nargs="?", const=True, type=lambda input_str: input_str.lower() == "true", help="filter spells with concentration. -con false will exclude concentration spells.")   
 
     return parser
 
@@ -43,7 +43,7 @@ def filter_spells(list, search_filters): # generic filtering method
     if school_filter:
         filtered_spells = filter_by_school(filtered_spells, school_filter[0])
 
-    if concentration_filter:
+    if concentration_filter is not None: # concentration_filter is a bool
         filtered_spells = filter_by_concentration(filtered_spells, concentration_filter)
 
     if level_filter:
@@ -79,7 +79,7 @@ def filter_by_component(list, filter_component, has_component=True):
     return filtered_spells
 
 
-def filter_by_concentration(list, is_concentration=True):
+def filter_by_concentration(list, is_concentration = True):
 
     filtered_spells = None
 

--- a/src/spell.py
+++ b/src/spell.py
@@ -1,6 +1,6 @@
 class Spell:
 
-    def __init__(self, name, school, level, duration, cast_time, cast_range, components, source, description, upcast, spell_lists):
+    def __init__(self, name, school, level, duration, cast_time, cast_range, components, source, description, upcast, spell_lists, ritual):
         self.name = name
         self.school = school
         self.level = level
@@ -12,6 +12,7 @@ class Spell:
         self.description = description
         self.upcast = upcast
         self.spell_lists = spell_lists
+        self.ritual = ritual
 
     def output(self):
         print(f"Name: {self.name}")
@@ -38,7 +39,8 @@ class Spell:
             "source": self.source,
             "description": self.description,
             "upcast": self.upcast,
-            "spell_lists": self.spell_lists
+            "spell_lists": self.spell_lists,
+            "ritual": self.ritual
         }
     
     def get_component(self, component_type): # returns the component matching the type provided ("V", "S", "M"). returns None if not found
@@ -65,6 +67,8 @@ class Spell:
         elif self.level[0].isnumeric():
             return int(self.level[0])
 
+    def is_ritual(self):
+        return self.ritual
 
     @classmethod
     def from_json(cls, json_data):


### PR DESCRIPTION
Implemented filtering by the ritual casting spell tag:
- Added the `ritual` attribute and `is_ritual` method to `Spell` in `spell.py`
- Created `filter_by_ritual` method in `search.py`
- Added the ritual argument to the argument parser & updated `filter_spells`
- Added the ritual argument to `/search` in `bot.py`
- Updated `display_spell` and `send_spell_embed` to include a spell's ritual status
- Added a row for the ritual argument in `display_help_menu`

Other changes:
- Created `filter_ua` and `filter_hb`, paving the way for the upcoming options menu
- Refactored concentration filtering. Argument parser now evaluates the user's input (or lack thereof) to a boolean value, allowing for simplified yet robust argument handling