### PR TITLE
Refactored cacher.py and renamed it to spell_manager.py

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,7 @@
 import discord
 from discord import app_commands
 from discord.ext import commands
-import src.cacher as cacher
+import src.spell_manager as sm
 import src.helpers as helpers
 import src.search as searcher
 from pathlib import Path
@@ -144,7 +144,7 @@ bot = commands.Bot(command_prefix="$", intents=intents)
 async def on_ready():
     print(f'Successfully logged in as {bot.user}')
 
-    bot.spells = cacher.initialize_spells()
+    bot.spells = sm.initialize_spells()
 
     if(bot.spells == None):
         print("Failed to initialize spells")

--- a/src/control.py
+++ b/src/control.py
@@ -1,7 +1,7 @@
 import requests
 from bs4 import BeautifulSoup
 from src import helpers
-from src import cacher
+from src import spell_manager as sm
 from src import search
 from pathlib import Path
 from rich.console import Console
@@ -149,7 +149,7 @@ def update_library(): # add missing spells to spells.txt, then returns re-initia
     console.print("[cyan2]Searching for new spells...[/]")
 
     try:
-        old_spells, new_spells = cacher.find_new_spells(return_old=True)
+        old_spells, new_spells = sm.find_new_spells(return_old=True)
     except FileNotFoundError:
         console.print("[cyan2]Failed to read spells.txt[/]")
         return None
@@ -165,8 +165,8 @@ def update_library(): # add missing spells to spells.txt, then returns re-initia
 
         if update_input.lower() in ['y', 'yes']:
             try:
-                cacher.save_spell_names(old_spells+new_spells)
-                updated_spells = cacher.initialize_spells()
+                sm.save_spell_names(old_spells+new_spells)
+                updated_spells = sm.initialize_spells()
                 console.print('[sea_green2]Spell library updated successfully.[/]')
                 return updated_spells
             except:
@@ -192,7 +192,7 @@ def main():
     console.print(Panel(ascii_header, style="bold yellow on purple4", box=box.ROUNDED))
 
 
-    spells = cacher.initialize_spells()
+    spells = sm.initialize_spells()
 
     if(spells == None):
         console.print("[orange_red1] Failed to initialize spells. Aborting program.[/]")
@@ -201,7 +201,7 @@ def main():
     # save spells to json if there is no backup
     file_path = Path('spells.json')
     if not file_path.is_file():
-        cacher.save_spells(helpers.jsonify_list(spells))
+        sm.save_spells(helpers.jsonify_list(spells))
         console.print("[bold chartreuse1]spells.json successfully created.[/]")
 
     # main control loop

--- a/src/spell_manager.py
+++ b/src/spell_manager.py
@@ -7,7 +7,7 @@ from src.spell import Spell
 from rich.progress import track
 from pathlib import Path
 
-def cache_spells(): # saves a list of all spell names to spells.txt
+def update_spells_txt(): # scrapes a list of all spell names, saves them to spells.txt
 
     spell_names = scrape_spell_names()
     save_spell_names(spell_names)
@@ -36,11 +36,11 @@ def scrape_spell_names(): # scrapes wikidot for a list of all spell names
     return spell_list
 
 
-def save_spell_names(list): # save a list of all spell names
+def save_spell_names(spell_list): # save a list of spell names to spells.txt
 
     with open('spells.txt', 'w') as f:
 
-        for spell in list:
+        for spell in spell_list:
             f.write(spell)
             f.write('\n')
 
@@ -67,7 +67,7 @@ def initialize_spells(backup=True): # loads spell data into memory. backup=False
     file_path = Path('spells.txt')
     if not file_path.is_file():
         try:
-            cache_spells()
+            update_spells_txt()
         except Exception as e:
             print("Failed to build spell index.")
             print(f"Error: {e}")
@@ -89,7 +89,7 @@ def initialize_spells(backup=True): # loads spell data into memory. backup=False
         json_list = []
 
         for i, new_spell_info in track(enumerate(data_into_list), description="Scraping spells from the web...", total=len(data_into_list)):
-            scraped_spell = helpers.scrape_spell(cache_search(helpers.reformat(new_spell_info)))
+            scraped_spell = helpers.scrape_spell(match_spell(helpers.reformat(new_spell_info)))
             json_list.append(scraped_spell)
 
         # remove bad data from list
@@ -104,40 +104,14 @@ def initialize_spells(backup=True): # loads spell data into memory. backup=False
     return None
 
 
-def save_spells(list): # save all spells to json
+def save_spells(spell_list): # save all spells to json
 
     with open('spells.json', 'w') as f:
-
-        json.dump(list, f, indent=4)
+        json.dump(spell_list, f, indent=4)
         f.close()
         
-        
-def read_cache():
-
-    spells = []
-
-    with open('spells.txt', 'r') as f:
-
-         spells = f.read()
-         
-    #print(spells)
-    data_into_list = spells.split("\n")
-    data_into_list.remove('')
-    #print(data_into_list)
     
-    for i, item in enumerate(data_into_list):
-    
-        data_into_list[i] = helpers.reformat(item)
-        #item = helpers.reformat(item)
-    
-    user_input = input("Enter spell name: ")
-    spell_found = get_close_matches(user_input, data_into_list, 1)
-    print('matched words:',spell_found)
-
-    return spell_found
-    
-    
-def cache_search(user_input): # searches spells.txt for input string, returns closest match
+def match_spell(user_input): # searches spells.txt for input string, returns closest match
 
     spells = []
 
@@ -165,15 +139,3 @@ def find_new_spells(return_old=False): # returns a list of scraped spell names n
         return [old_spells, new_spells]
     else:
         return new_spells
-
-     
-def main():
-
-    print("Caching...")
-
-    cache_spells()
-    read_cache()
-
-	
-if __name__ == "__main__":
-    main() 


### PR DESCRIPTION
Made the following changes to `cacher.py` to increase clarity:
- Renamed the module to `spell_manager.py` to more accurately reflect the module's functionality
- Renamed the `cache_spells` method to `update_spells_txt` (still not 100% about this name, honestly the method itself might be redundant)
- Renamed `cache_search` method to `match_spell` to reflect how it returns the closest matching spell name from `spells.txt`
- Renamed all method parameters called `list` to more descriptive things such as `spell_list` to help disambiguate it from the built-in list type
- Removed the `read_cache` method as it was a holdover from early prototyping and has been made redundant by `match_spell`

This PR also updates imports in `control.py` and `bot.py` to reflect the module's renaming.