### PR TITLE
Bot & parsing improvements

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -52,6 +52,21 @@ def paginated_description(spell, desc_length=140):
 def add_paginated_spell(embed, spell):
     embed.add_field(name=spell.name+" *("+combine_level_and_school(spell)+")*", value="-# "+paginated_description(spell), inline=False)
 
+# returns an embed colour based on a spell's school
+def get_school_colour(school_name):
+    colour_map = {
+        "Abjuration": discord.Color.blurple(),
+        "Conjuration": discord.Color.purple(),
+        "Divination": discord.Color.teal(),
+        "Enchantment": discord.Color.fuchsia(),
+        "Evocation": discord.Color.red(),
+        "Illusion": discord.Color.blue(),
+        "Necromancy": discord.Color.brand_green(),
+        "Transmutation": discord.Color.yellow()
+    }
+    return colour_map.get(school_name, discord.Color.blue())
+
+
 # creates an embed card with a specified spell's details (for /spell)
 async def send_spell_embed(message, spell):
 
@@ -71,7 +86,7 @@ async def send_spell_embed(message, spell):
     spell_embed = discord.Embed(
         title=spell.name,
         description=f"*{spell_school_level}*\n",
-        color=discord.Color.blue() # TODO maybe change this based on spell school?
+        color=get_school_colour(spell.school)
     )
 
     spell_embed.add_field(name="🕒 Duration", value=spell.duration, inline=False)
@@ -129,7 +144,10 @@ async def send_paginated_embed(message, spells, page=0, per_page=10):
             page_embed.set_footer(text=f"Page {page + 1} of {last_page_index + 1}")
 
             await sent_message.edit(embed=page_embed)
-            await sent_message.remove_reaction(reaction.emoji, user)
+            try:
+                await sent_message.remove_reaction(reaction.emoji, user)
+            except:
+                print("Failed to remove reaction. Does the bot have the Manage Messages permission?")
 
         except asyncio.TimeoutError: # exit the loop after timeout (30 sec)
             break

--- a/bot.py
+++ b/bot.py
@@ -64,6 +64,7 @@ def get_school_colour(school_name):
         "Necromancy": discord.Color.brand_green(),
         "Transmutation": discord.Color.yellow()
     }
+
     return colour_map.get(school_name, discord.Color.blue())
 
 
@@ -180,8 +181,17 @@ async def on_ready():
 @app_commands.rename(spell_name="name")
 async def spell(interaction: discord.Interaction, spell_name: str):
     target_spell = searcher.fetch_spell(bot.spells, spell_name)
-    spell_embed = await send_spell_embed(interaction, target_spell)
-    await interaction.response.send_message(embed=spell_embed)
+    if not target_spell:
+        spell_names = [spell.name for spell in bot.spells]
+        weak_matches = helpers.find_closest_spell(spell_names, spell_name, num_results=3, similarity=0.4)
+        if not weak_matches:
+            await interaction.response.send_message(content="Couldn't find a spell with that name.", ephemeral=True)
+        else:
+            await interaction.response.send_message(content="Couldn't find a spell with that name. Maybe you meant one of these?\n"+", ".join(weak_matches), ephemeral=True)
+    else:
+        spell_embed = await send_spell_embed(interaction, target_spell)
+        await interaction.response.send_message(embed=spell_embed)
+
 
 @bot.tree.command(name="search", description='Lists spells that match your search criteria')
 @app_commands.describe(spell_class = "Filter for spells available to specific classes (separated by spaces)", school = "Filter for spells belonging to a specific school", level = "Filter based on spell levels (\"0-3\" includes spells from cantrips to level 3)", 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -170,9 +170,10 @@ def clean_list(spell_list): # removes invalid & duplicate items from a provided 
     return final_list
 
 
-def find_closest_spell(spell_list, target): # finds closest matching spell name in a list of strings
+def find_closest_spell(spell_list, target, num_results = 1, similarity=0.6): # finds closest matching spell name in a list of strings
 
     try:
-        return get_close_matches(target, spell_list, 1)[0]
+        matches = get_close_matches(target, spell_list, n=num_results, cutoff=similarity)
+        return matches[0] if num_results==1 else matches
     except:
         return None

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -17,8 +17,9 @@ def scrape_spell_json(spell_name): # scrape spell's info, returns as json
     page = requests.get(URL)
 
     soup = BeautifulSoup(page.content, "html.parser")
-    
-    return parse_to_json(soup, soup.title.get_text().split(' -')[0])
+    results = soup.find(id="page-content")
+
+    return parse_to_json(results, soup.title.get_text().split(' -')[0])
 
 
 def scrape_spell(spell_name): # scrape spell's info, returns as Spell object
@@ -68,7 +69,7 @@ def parse_to_json(soup, name): # converts scraped html to json
     spell_lists = []
     is_ritual = False
 
-    spell_html = soup.find_all('p')
+    spell_html = soup.find_all(['p','ul'])
 
     # handling spell school and level
     emphasis = soup.find("em")


### PR DESCRIPTION
# Bot improvements
- `/spell` command now notifies users if a match couldn't be found and will suggest up to three spell names that match their input more weakly.
- The colour of spell embeds now correspond to the school of the spell.
- Spell embeds now have handling for extraordinarily long spell descriptions (ex. Wish, Symbol, Illusory Dragon).
## new methods in `bot.py`
- `get_school_colour`, a method that takes a spell school as a parameter and returns the colour mapped to it
- `find_good_cutoff`, a method that trims a string to adhere to a character limit. Attempts to find a natural cutoff point near the end of the trimmed string. Prioritizes cutting off at the end of a sentence, or at the end of a word if no periods are present.
- `create_embed_desc`, a recursive method for adding description fields to a spell embed. Descriptions that exceed the character limit are broken up by `find_good_cutoff` and appended to a provided embed as separate fields. 

# Parsing improvements
- The parser now only looks at `page-content`, making it more robust and focused on meaningful data.
- `<ul>` tags are now parsed as well due to their occasional use in spell descriptions (Wish, Symbol, Eyebite).
- `find_closest_spell` has been expanded with the optional arguments `num_results` and `similarity`, which modify the number of matches returned and the similarity threshold of the matching algorithm.